### PR TITLE
Links to first meeting docs, new post

### DIFF
--- a/_posts/2017-04-04-updated-information.md
+++ b/_posts/2017-04-04-updated-information.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title:  "Sign-up Sheets Arriving This Week"
+date:   2017-04-04 22:00:00 -0500
+categories: update
+---
+Greetings, Students and Mentors!
+
+It has been barely a week since the Mentors gathered in the Choir room of Lake
+Middle School to discuss the future of our organization! The website is starting
+to take shape as a hub for information. On the [Documentation](/docs) page,
+you'll find references to the [information sheet][sheet] and [presentation slides][slides]
+from our first general meeting on March 20, 2017.
+
+This week, sign-up sheets will be made available to students at school, but you
+should watch this website. Once it is sent to the students, we'll post it here.
+
+[slides]: https://drive.google.com/open?id=0B7O54woMLwgSS0JhU3JJUVViZjQ
+[sheet]: https://drive.google.com/open?id=0B7O54woMLwgSV19ocUlSN1Q5SEE

--- a/docs.md
+++ b/docs.md
@@ -8,6 +8,15 @@ permalink: /docs/
 There is an [on-line wiki][wiki], a collaborative site to collect and edit
 documentation, for the club.
 
+## Documents from the First Meeting (March 20, 2017)
+
+- [Information Presentation Slides](https://drive.google.com/open?id=0B7O54woMLwgSS0JhU3JJUVViZjQ)
+- [Basic Information](https://drive.google.com/open?id=0B7O54woMLwgSV19ocUlSN1Q5SEE)
+
+## Sign-up Sheet (Due April 24, 2017)
+
+*Coming Soon*
+
 ## Google Docs Drive
 
 For mentors and students, there is also a shared [Google Drive folder][gdrive] to collect


### PR DESCRIPTION
I added the links to the information slides and basic information handout on the
/docs/ page. Additionally, I added a small announcement post to keep people
updated.