### PR TITLE
Liberty Ridge Update, Sponsors, Calendar

### DIFF
--- a/_posts/2018-02-22-libertyridge.md
+++ b/_posts/2018-02-22-libertyridge.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title:  "STEM Outreach at Liberty Ridge Elementary"
+date:   2018-02-22 21:00:00 -0500
+categories: update
+---
+
+Tuesday evening on February 22, 2018 at the Liberty Ridge Elementary School, the
+gymnasium was packed with amazing science experiments conducted and presented by
+the hopeful youth of Woodbury. _8-Bit Leopards_ and _The MEME Team_, having recently
+finished their competition season in late January, visited for a friendly bit of
+competition and to share their experiences with the curious students and parents
+of Liberty Ridge.
+
+From 6:00 PM to 7:10, the two teams prepared their robots for the match,
+practicing in the game field. Some lucky elementary students got to drive the
+bots, collecting the glyphs from the center of the field and placing them in the
+cryptoboxes. Parents commented on how they would have loved to have something
+these bots when they were younger and were excited that in the very near future,
+their kids may soon be part of these very teams.
+
+At 7:10, Kyle Mestery, lead mentor for _8-Bit Leopards_ introduced the teams,
+their bots, and talked a bit about FIRST Tech Challenge. Devan Lauren Vance from
+_8-Bit Leopards_ and Connor Walstrom from _The MEME Team_ addressed the crowd,
+explaining what the objectives of the match were and what they were about to see
+the bots do. With a quick countdown, the bots went in to action.
+
+In autonomous mode, the bots each obtained their primary objectives. _The MEME
+Team_ entered the safe spot, while _8-Bit Leopards_ knocked off a valuable jewel.
+
+In tele-op mode, recently damaged Twitchy, _the MEME Team_ bot, managed to push
+three glyphs into the cryptobox with its unusable arm before coming to a halt in
+front of the balance tile -- the REV Hub having lost connection. _The 8-Bit
+Leopards_ bot successfully deposited a number of glyphs into the cryptobox and
+attempted to get back on to the balance tile.
+
+It was great to see the excited and interested faces of the crowd, parents and
+students alike. With registration soon to open for the 2018-2019 season, please
+look to this space for updates and consider mentoring! With a great level of
+interest, we need an equally great level of support.

--- a/about.md
+++ b/about.md
@@ -9,7 +9,7 @@ Spring of 2017. It is composed of multiple teams of between 6 and 15 children
 and 2 to 4 mentors.
 
 If you are a student or mentor interested in becoming involved with the
-2017-2018 season, please subscribe to the [leopardrobotics-discuss][lr-discuss]
+2018-2019 season, please subscribe to the [leopardrobotics-discuss][lr-discuss]
 email list on [Google Groups][gg] and introduce yourself.
 
 If you're interested in volunteering as a mentor, please subscribe to

--- a/calendar.md
+++ b/calendar.md
@@ -1,14 +1,21 @@
 ---
 layout: page
-title: Calendar
+title: Calendars
 permalink: /calendar/
 ---
-{{ site.title }} uses [Google Calendar][calendar] to publish its events. It can
-be viewed here as [HTML][lr-cal-html], imported as [ICAL][lr-cal-ical], or
-subscribed to in Google Calendar.
 
-<iframe src="https://calendar.google.com/calendar/embed?src=4b723fvk23nkoqv0p2bl0pc144%40group.calendar.google.com&ctz=America/Chicago" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+{{ site.title }} uses Basecamp Schedules[^1] to publish its events. The Club
+calendar is publicly accessible here. Expect to find club-level events and
+mentor meeting announcements here.
 
-[calendar]: https://calendar.google.com/
-[lr-cal-html]: https://calendar.google.com/calendar/embed?src=4b723fvk23nkoqv0p2bl0pc144%40group.calendar.google.com&ctz=America/Chicago
-[lr-cal-ical]: https://calendar.google.com/calendar/ical/4b723fvk23nkoqv0p2bl0pc144%40group.calendar.google.com/public/basic.ics
+- [Club Calendar](https://public.3.basecamp.com/p/izdJC3cwWLxWyBV5azrEFWX7 "Club Calendar")
+
+Within Basecamp, there are separate calendars for Team and Mentors. If you are a
+Team member of Mentor, you will be assigned appropriately and will have access
+to these calendars, which you can link or import into your favorite calendaring
+application. For more information on using these calendars in Basecamp, visit
+[Basecamp Support](https://3.basecamp-help.com/article/49-schedule "Basecamp
+Support for Schedules").
+
+
+[^1]: _The old Google Calendar has not been used since we adopted Basecamp as our club platform._

--- a/docs.md
+++ b/docs.md
@@ -3,6 +3,7 @@ layout: page
 title: Documentation
 permalink: /docs/
 ---
+
 ## Wiki
 
 There is an [on-line wiki][wiki], a collaborative site to collect and edit
@@ -13,9 +14,9 @@ documentation, for the club.
 - [Information Presentation Slides](https://drive.google.com/open?id=0B7O54woMLwgSS0JhU3JJUVViZjQ)
 - [Basic Information](https://drive.google.com/open?id=0B7O54woMLwgSV19ocUlSN1Q5SEE)
 
-## Sign-up Sheet (Due May 1, 2017)
+## Sign-up Sheet for 2018-2019 Season
 
-- [Sign-up Sheet](https://drive.google.com/open?id=1gE4w-G6pWufq-snQA_k95VCw7HfDCNvlc92kXj0I-D8)
+- Sign-up Sheet (Coming Soon)
 
 ## Google Docs Drive
 

--- a/sponsor.md
+++ b/sponsor.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Sponsors
+permalink: /sponsors/
+---
+## 3M
+
+In 2017, [3M Foundation](http://grantsoffice.com/GrantDetails.aspx?gid=8548)
+graciously awarded the Lake Middle School Robotics Club an $8,500 grant to start
+our five teams, giving 75 students the opportunity to experience STEM in a big
+way!
+
+## Donaldson Foundation
+
+In 2017, [Donaldson
+Foundation](https://www.donaldson.com/en-us/about-us/company-information/community-involvement/)
+awarded the Lake Middle School Robotics Club a $1,000 gift, allowing our club to
+purchase a competition field and game set! Used in practice and in STEM
+Outreach, this field has given the students the ability to see their robots in
+action outside of official competition.
+
+## Basecamp
+
+[Basecamp for Education](https://basecamp.com/discounts) is a project management
+website application that provides our students, parents, and mentors a unified
+platform for communication, coordination, and cooperation. Rather than having to
+use multiple applications for multiple functions, Basecamp provides all of this
+functionality free for Educational use.
+
+## GitHub
+
+[GitHub Education](https://education.github.com/) is program that provides our
+FIRST students premium features of GitHub for free. With GitHub, students can
+save and share their work amongst their teammates, learn good coding practices,
+and stay organized.


### PR DESCRIPTION
Updated a number of pages with this commit. The Calendar page now refers to the
public URL for the Basecamp Schedule - our primary calendar now. The sign-up
link was removed, soon to be replaced. The About page needs more work. A new
Sponsors page was added. Media to come soon.